### PR TITLE
FIX: git divergent branches

### DIFF
--- a/gimera/repo.py
+++ b/gimera/repo.py
@@ -210,7 +210,7 @@ class Repo(GitCommands):
         if not remote and not ref:
             raise Exception("Requires remote and ref or yaml configuration.")
 
-        self.X("git", "pull", "--no-edit", remote, ref)
+        self.X("git", "pull", "--no-edit", "--no-rebase", remote, ref)
 
     def full_clean(self):
         self.X("git", "checkout", "-f")


### PR DESCRIPTION
Without the --no-rebase parameter we are getting errors on pull the merge request
```
hint: You have divergent branches and need to specify how to reconcile them.
hint: You can do so by running one of the following commands sometime before
hint: your next pull:
hint: 
hint:   git config pull.rebase false  # merge
hint:   git config pull.rebase true   # rebase
hint:   git config pull.ff only       # fast-forward only
hint: 
hint: You can replace "git config" with "git config --global" to set a default
hint: preference for all repositories. You can also pass --rebase, --no-rebase,
hint: or --ff-only on the command line to override the configured default per
hint: invocation.
```