### PR TITLE
[FIX] "git submodule--helper list" missing

### DIFF
--- a/gimera/gimera.py
+++ b/gimera/gimera.py
@@ -923,19 +923,16 @@ def _check_all_submodules_initialized():
     root = Path(os.getcwd())
 
     def _get_all_submodules(root):
-
-        for path in (
-            Repo(root).out("git", "submodule--helper", "list").strip().splitlines()
-        ):
-            path = root / path.split("\t", 1)[1]
-            yield path
-            if path.exists():
+        for submodule in Repo(root).get_submodules():
+            path = submodule.path
+            yield submodule
+            if submodule._git_path.exists():
                 yield from _get_all_submodules(path)
 
     error = False
-    for path in _get_all_submodules(root):
-        if not path.exists():
-            click.secho(f"Not initialized: {path}", fg="red")
+    for submodule in _get_all_submodules(root):
+        if not submodule._git_path.exists():
+            click.secho(f"Not initialized: {submodule.path}", fg="red")
             error = True
 
     return not error

--- a/gimera/repo.py
+++ b/gimera/repo.py
@@ -21,7 +21,7 @@ class Repo(GitCommands):
     def rel_path_to_root_repo(self):
         assert str(self.path).startswith("/")
         return self.path.relative_to(self.root_repo.path)
-
+    
     @property
     def root_repo(self):
         path = self.path
@@ -31,6 +31,9 @@ class Repo(GitCommands):
             path = path.parent
         else:
             return None
+    @property
+    def _git_path(self):
+        return (self.path / ".git")
 
     def ls_files_states(self, params):
         """
@@ -121,10 +124,10 @@ class Repo(GitCommands):
 
     @yieldlist
     def get_submodules(self):
-        submodules = self.out("git", "submodule--helper", "list").splitlines()
+        submodules = self.out("git", "submodule", "status").splitlines()
         for line in submodules:
-            splitted = line.strip().split("\t", 3)
-            yield Submodule(self.next_module_root / splitted[-1], self.next_module_root)
+            splitted = line.strip().split(" ")
+            yield Submodule(self.next_module_root / splitted[1], self.next_module_root)
 
     def _fix_to_remove_subdirectories(self, config):
         # https://stackoverflow.com/questions/4185365/no-submodule-mapping-found-in-gitmodule-for-a-path-thats-not-a-submodule


### PR DESCRIPTION
I got this error after updating my system.
`Schwerwiegend: 'list' ist kein gültiger Unterbefehl von submodule--helper
/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.7) or chardet (3.0.4) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "
Traceback (most recent call last):
  File "/home/mt/.local/bin/gimera", line 8, in <module>
    sys.exit(cli())
  File "/home/mt/.local/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/mt/.local/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/mt/.local/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/mt/.local/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/mt/.local/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/mt/.local/lib/python3.8/site-packages/gimera/gimera.py", line 282, in apply
    return _apply(
  File "/home/mt/.local/lib/python3.8/site-packages/gimera/gimera.py", line 313, in _apply
    _internal_apply(
  File "/home/mt/.local/lib/python3.8/site-packages/gimera/gimera.py", line 339, in _internal_apply
    _turn_into_correct_repotype(main_repo, repo, config)
  File "/home/mt/.local/lib/python3.8/site-packages/gimera/gimera.py", line 869, in _turn_into_correct_repotype
    submodules = repo.get_submodules()
  File "/home/mt/.local/lib/python3.8/site-packages/gimera/tools.py", line 10, in wrapper
    result = list(method(*args, **kwargs))
  File "/home/mt/.local/lib/python3.8/site-packages/gimera/repo.py", line 124, in get_submodules
    submodules = self.out("git", "submodule--helper", "list").splitlines()
  File "/home/mt/.local/lib/python3.8/site-packages/gimera/gitcommands.py", line 32, in out
    return X(*params, output=True, cwd=self.path, allow_error=allow_error)
  File "/home/mt/.local/lib/python3.8/site-packages/gimera/tools.py", line 18, in X
    return subprocess.check_output(params, encoding="utf-8", cwd=cwd).rstrip()
  File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'submodule--helper', 'list']' returned non-zero exit status 128.`

This PR replaces "git submodule--helper list" with "git submodule status"