### PR TITLE
ci: enable parallel test execution with pytest-xdist

### DIFF
--- a/.github/workflows/gimera-pytest.yml
+++ b/.github/workflows/gimera-pytest.yml
@@ -31,14 +31,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest click inquirer pyyaml
+        pip install flake8 pytest pytest-xdist click inquirer pyyaml
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Test with pytest
       run: |
         git config --global user.email test@gimera.de
         git config --global user.name gimera
-        pytest
+        pytest -n auto
 
   check-changelog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Install `pytest-xdist` in CI pipeline
- Run tests with `pytest -n auto` for parallel execution

## Test plan
- [ ] Verify CI pipeline runs tests in parallel
- [ ] Check that all tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)